### PR TITLE
Fix search engine of pkgdown by specifying full URL

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: ~
+url: https://biogeomacro.github.io/GIFT/
 template:
   bootstrap: 5
 


### PR DESCRIPTION
I realized there was an issue in the built-in search engine of the pkgdown website.
Let's say I'm interested in looking for "suitable polygons" in the documentation.
If I type this in the search field, it redirects to:
```
https://biogeomacro.github.io/reference/GIFT_checklist_conditional.html?q=suitable%20polygon#arguments
```

while the correct URL would be (note the added **/GIFT**):
```
https://biogeomacro.github.io/GIFT/reference/GIFT_checklist_conditional.html?q=suitable%20polygon#arguments
```

Checking on pkgdown documentation about [built-in search](https://pkgdown.r-lib.org/articles/search.html) it seems that it's because the URL of the website is not specified in the `_pkgdown.yml` file. So I'm hoping this PR would help solve that!